### PR TITLE
Fix poetry install script

### DIFF
--- a/manage_fastapi/templates/project/{{ cookiecutter.folder_name }}/Dockerfile
+++ b/manage_fastapi/templates/project/{{ cookiecutter.folder_name }}/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONPATH "${PYTHONPATH}:/"
 ENV PORT=8000
 {% if cookiecutter.packaging == "poetry" %}
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org/ | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
The current URL for installing poetry is not working when choosing to have a docker image.